### PR TITLE
Fix upload limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,24 @@ https://www.rust-lang.org/tools/install
 2. Run the server
 `cargo run`
 
-## Run tests
+## Testing
+
+### Run tests
 
 Run the integration tests:
 `cargo test`
+
+### Test upload endpoint
+
+For testing purposes you could create a file with random data using for example [dd](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/dd.html) from the terminal. The following command creates 1 MB of data:
+```
+dd if=/dev/random of=random_data.bin bs=1M count=1
+```
+
+You can then POST data to the endpoint `/upload` with:
+```
+curl -i -X POST --data-binary @random_data.bin -H "Content-type: application/json" http://localhost:{PORT}/upload
+````
 
 ## Deployment
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use actix_web::{
 };
 use log::info;
 
-const MAX_PAYLOAD_SIZE: usize = 10000000; // 10 Megabyte
+const MAX_PAYLOAD_SIZE: usize = 10485760; // 10 Megabyte
 
 async fn health(req: HttpRequest) -> HttpResponseBuilder {
     info!("Received health ping");

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use actix_web::{
 };
 use log::info;
 
-const MAX_PAYLOAD_SIZE: usize = 80000000; // 10 Megabyte
+const MAX_PAYLOAD_SIZE: usize = 10000000; // 10 Megabyte
 
 async fn health(req: HttpRequest) -> HttpResponseBuilder {
     info!("Received health ping");


### PR DESCRIPTION
Sets the upload limit actually to `10 MB` and adds instructions on how to test `/upload`.